### PR TITLE
Splitter: return a List instead of Flux

### DIFF
--- a/function/README.adoc
+++ b/function/README.adoc
@@ -7,4 +7,6 @@ The functions can be run as part of standalone Spring Boot applications.
 
 `splitter-function`
 
-TODO: provide a description
+This is a "one-to-many" Java function with a signature as `Function<Message<?>, List<Message<?>>>`. So, every inbound message is splitted into several output messages.
+This function is fuly based on the Spring integration `AbstractMessageSplitter` and supports a `delimiters`, `expression`, `applySequence` properties.
+Also if one of the `fileMarkers` or `charset` properties is present, the `FileSplitter` implementation is used and an incoming payload is treated as file for splitting.

--- a/function/splitter-function/pom.xml
+++ b/function/splitter-function/pom.xml
@@ -37,18 +37,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
         </dependency>
     </dependencies>
-
 
     <build>
         <plugins>
@@ -69,20 +69,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-                <configuration>
-                    <includes>
-                        <include>**/*Tests.java</include>
-                        <include>**/*Test.java</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>
@@ -97,65 +83,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <repository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/libs-snapshot-local</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/libs-milestone-local</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>spring-releases</id>
-            <name>Spring Releases</name>
-            <url>https://repo.spring.io/release</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/libs-snapshot-local</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </pluginRepository>
-        <pluginRepository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/libs-milestone-local</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-        <pluginRepository>
-            <id>spring-releases</id>
-            <name>Spring Releases</name>
-            <url>https://repo.spring.io/libs-release-local</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
 
 </project>

--- a/function/splitter-function/src/test/java/io/pivotal/java/function/splitter/function/SplitterFunctionApplicationTests.java
+++ b/function/splitter-function/src/test/java/io/pivotal/java/function/splitter/function/SplitterFunctionApplicationTests.java
@@ -1,44 +1,45 @@
+/*
+ * Copyright (c) 2011-2020 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.pivotal.java.function.splitter.function;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
 import java.util.function.Function;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
-import reactor.core.publisher.Flux;
-import reactor.test.StepVerifier;
-
-@RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(properties = "splitter.expression=payload.split(',')")
 @DirtiesContext
-public abstract class SplitterFunctionApplicationTests {
+public class SplitterFunctionApplicationTests {
 
 	@Autowired
-	protected Function<Message<?>, Flux<Message<?>>> splitter;
+	Function<Message<?>, List<Message<?>>> splitter;
 
-	@TestPropertySource(properties = "splitter.expression=payload.split(',')")
-	public static class UsingExpressionIntegrationTests extends SplitterFunctionApplicationTests {
-
-		@Test
-		public void test() {
-			Flux<Message<?>> messageFlux = this.splitter.apply(new GenericMessage<>("hello,world"));
-
-			StepVerifier.create(
-					messageFlux
-							.map(Message::getPayload)
-							.cast(String.class))
-					.expectNext("hello", "world")
-					.verifyComplete();
-		}
-
+	@Test
+	public void testExpressionSplitter() {
+		List<Message<?>> messageList = this.splitter.apply(new GenericMessage<>("hello,world"));
+		assertThat(messageList).extracting(m -> m.getPayload().toString()).contains("hello", "world");
 	}
 
 }


### PR DESCRIPTION
It turns out that partially reactive functions are not supported (yet) in Spring Cloud Function
& Spring Cloud Stream

* Rework a `splitter-function` to return a `List<Message<?>>` instead of `Flux<Message<?>>` -
and now Spring Cloud Stream can understand that we would like to produce several messages
into a target destination

Related to https://github.com/spring-cloud/spring-cloud-stream/issues/1896