### PR TITLE
Upgrade to Spring Boot 2.3 M2

### DIFF
--- a/consumer/cassandra-consumer/pom.xml
+++ b/consumer/cassandra-consumer/pom.xml
@@ -14,8 +14,8 @@
 	</parent>
 
 	<properties>
-		<springIntegrationCassandara.version>0.7.0.RELEASE</springIntegrationCassandara.version>
-		<cassandra-unit-spring.version>3.11.2.0</cassandra-unit-spring.version>
+		<springIntegrationCassandara.version>0.8.0.BUILD-SNAPSHOT</springIntegrationCassandara.version>
+		<cassandra-unit-spring.version>4.3.1.0</cassandra-unit-spring.version>
 	</properties>
 
 	<dependencies>

--- a/consumer/cassandra-consumer/pom.xml
+++ b/consumer/cassandra-consumer/pom.xml
@@ -55,6 +55,12 @@
 			<artifactId>cassandra-unit-spring</artifactId>
 			<version>${cassandra-unit-spring.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.addthis.metrics</groupId>
+					<artifactId>reporter-config3</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.projectreactor</groupId>

--- a/consumer/cassandra-consumer/src/main/java/io/pivotal/java/function/cassandra/consumer/CassandraConsumerConfiguration.java
+++ b/consumer/cassandra-consumer/src/main/java/io/pivotal/java/function/cassandra/consumer/CassandraConsumerConfiguration.java
@@ -27,7 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.data.cassandra.core.InsertOptions;
 import org.springframework.data.cassandra.core.ReactiveCassandraOperations;
 import org.springframework.data.cassandra.core.UpdateOptions;

--- a/consumer/cassandra-consumer/src/main/java/io/pivotal/java/function/cassandra/consumer/CassandraConsumerProperties.java
+++ b/consumer/cassandra-consumer/src/main/java/io/pivotal/java/function/cassandra/consumer/CassandraConsumerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.expression.Expression;
 import org.springframework.integration.cassandra.outbound.CassandraMessageHandler;
 
-import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
 
 /**
  * @author Artem Bilan

--- a/consumer/cassandra-consumer/src/main/java/io/pivotal/java/function/cassandra/consumer/cluster/CassandraAppClusterConfiguration.java
+++ b/consumer/cassandra-consumer/src/main/java/io/pivotal/java/function/cassandra/consumer/cluster/CassandraAppClusterConfiguration.java
@@ -84,7 +84,7 @@ public class CassandraAppClusterConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = "cassandra.cluster", name = "createKeyspace")
+	@ConditionalOnProperty("cassandra.cluster.create-keyspace")
 	public Object keyspaceCreator(CassandraProperties cassandraProperties, CqlSessionBuilder cqlSessionBuilder) {
 		CreateKeyspaceSpecification createKeyspaceSpecification =
 				CreateKeyspaceSpecification
@@ -111,7 +111,7 @@ public class CassandraAppClusterConfiguration {
 
 
 	@Bean
-	@ConditionalOnProperty(prefix = "cassandra.cluster", name = "initScript")
+	@ConditionalOnProperty("cassandra.cluster.init-script")
 	public Object keyspaceInitializer(CassandraClusterProperties cassandraClusterProperties,
 			ReactiveCassandraTemplate reactiveCassandraTemplate) throws IOException {
 

--- a/consumer/cassandra-consumer/src/main/java/io/pivotal/java/function/cassandra/consumer/cluster/CassandraAppClusterConfiguration.java
+++ b/consumer/cassandra-consumer/src/main/java/io/pivotal/java/function/cassandra/consumer/cluster/CassandraAppClusterConfiguration.java
@@ -17,22 +17,17 @@
 package io.pivotal.java.function.cassandra.consumer.cluster;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Scanner;
 
-import javax.annotation.PostConstruct;
-
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanInitializationException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.autoconfigure.cassandra.CassandraProperties;
-import org.springframework.boot.autoconfigure.cassandra.ClusterBuilderCustomizer;
+import org.springframework.boot.autoconfigure.cassandra.CqlSessionBuilderCustomizer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.data.cassandra.CassandraReactiveDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScanPackages;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
@@ -44,6 +39,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.data.cassandra.config.CqlSessionFactoryBean;
 import org.springframework.data.cassandra.core.ReactiveCassandraTemplate;
 import org.springframework.data.cassandra.core.cql.CqlTemplate;
 import org.springframework.data.cassandra.core.cql.ReactiveCqlOperations;
@@ -51,9 +47,8 @@ import org.springframework.data.cassandra.core.cql.generator.CreateKeyspaceCqlGe
 import org.springframework.data.cassandra.core.cql.keyspace.CreateKeyspaceSpecification;
 import org.springframework.util.StringUtils;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.RemoteEndpointAwareJdkSSLOptions;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import reactor.core.publisher.Flux;
 
 /**
@@ -67,55 +62,65 @@ import reactor.core.publisher.Flux;
 public class CassandraAppClusterConfiguration {
 
 	@Bean
-	@ConditionalOnProperty(prefix = "cassandra.cluster", name = "createKeyspace")
-	public static BeanPostProcessor createKeySpacePostProcessor(CassandraProperties cassandraProperties) {
+	public static CqlSessionBuilderCustomizer clusterBuilderCustomizer(
+			CassandraClusterProperties cassandraClusterProperties) {
 
-		return new BeanPostProcessor() {
+		PropertyMapper map = PropertyMapper.get();
+		return builder ->
+				map.from(cassandraClusterProperties::isSkipSslValidation)
+						.whenTrue()
+						.toCall(() -> {
+							try {
+								builder.withSslContext(TrustAllSSLContextFactory.getSslContext());
+							}
+							catch (NoSuchAlgorithmException | KeyManagementException e) {
+								throw new BeanInitializationException(
+										"Unable to configure a Cassandra cluster using SSL.", e);
+							}
 
-			@Override
-			public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-				if (bean instanceof Cluster) {
-					CreateKeyspaceSpecification createKeyspaceSpecification =
-							CreateKeyspaceSpecification
-									.createKeyspace(cassandraProperties.getKeyspaceName())
-									.withSimpleReplication()
-									.ifNotExists();
-
-					String createKeySpaceQuery = new CreateKeyspaceCqlGenerator(createKeyspaceSpecification).toCql();
-
-					try (Session session = ((Cluster) bean).connect()) {
-						CqlTemplate template = new CqlTemplate(session);
-						template.execute(createKeySpaceQuery);
-					}
-				}
-				return bean;
-			}
-		};
-
+						});
 	}
 
 	@Bean
-	public ClusterBuilderCustomizer clusterBuilderCustomizer(CassandraClusterProperties cassandraClusterProperties) {
-		PropertyMapper map = PropertyMapper.get();
-		return builder -> {
-			map.from(cassandraClusterProperties::isMetricsEnabled)
-					.whenFalse()
-					.toCall(builder::withoutMetrics);
-			map.from(cassandraClusterProperties::isSkipSslValidation)
-					.whenTrue()
-					.toCall(() -> {
-						RemoteEndpointAwareJdkSSLOptions.Builder optsBuilder =
-								RemoteEndpointAwareJdkSSLOptions.builder();
-						try {
-							optsBuilder.withSSLContext(TrustAllSSLContextFactory.getSslContext());
-						}
-						catch (NoSuchAlgorithmException | KeyManagementException e) {
-							throw new BeanInitializationException(
-									"Unable to configure a Cassandra cluster using SSL.", e);
-						}
-						builder.withSSL(optsBuilder.build());
-					});
-		};
+	@ConditionalOnProperty(prefix = "cassandra.cluster", name = "createKeyspace")
+	public static Object keyspaceCreator(CassandraProperties cassandraProperties, CqlSessionBuilder cqlSessionBuilder) {
+		CreateKeyspaceSpecification createKeyspaceSpecification =
+				CreateKeyspaceSpecification
+						.createKeyspace(cassandraProperties.getKeyspaceName())
+						.withSimpleReplication()
+						.ifNotExists();
+
+		String createKeySpaceQuery = new CreateKeyspaceCqlGenerator(createKeyspaceSpecification).toCql();
+		CqlSession systemSession =
+				cqlSessionBuilder.withKeyspace(CqlSessionFactoryBean.CASSANDRA_SYSTEM_SESSION).build();
+
+		CqlTemplate template = new CqlTemplate(systemSession);
+		template.execute(createKeySpaceQuery);
+
+		return null;
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "cassandra.cluster", name = "initScript")
+	public static Object keyspaceInitializer(CassandraClusterProperties cassandraClusterProperties,
+			ReactiveCassandraTemplate reactiveCassandraTemplate) throws IOException {
+
+		String scripts =
+				new Scanner(cassandraClusterProperties.getInitScript().getInputStream(),
+						StandardCharsets.UTF_8.name())
+						.useDelimiter("\\A")
+						.next();
+
+		ReactiveCqlOperations reactiveCqlOperations =
+				reactiveCassandraTemplate.getReactiveCqlOperations();
+
+		Flux.fromArray(StringUtils.delimitedListToStringArray(scripts, ";", "\r\n\f"))
+				.filter(StringUtils::hasText) // an empty String after the last ';'
+				.flatMap(script -> reactiveCqlOperations.execute(script + ";"))
+				.blockLast();
+
+		return null;
+
 	}
 
 	static class CassandraPackageRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {
@@ -135,40 +140,6 @@ public class CassandraAppClusterConfiguration {
 					.bind("cassandra.cluster.entity-base-packages", String[].class)
 					.map(Arrays::asList)
 					.ifBound(packagesToScan -> EntityScanPackages.register(registry, packagesToScan));
-		}
-
-	}
-
-	/**
-	 * Inner class to execute init scripts on the provided {@code keyspace}.
-	 * It is here to bypass circular dependency with {@link ReactiveCassandraTemplate} injection
-	 * and its {@code @amp;Bean} in the {@link CassandraReactiveDataAutoConfiguration}.
-	 */
-	@Configuration
-	protected static class CassandraKeyspaceInitializerConfiguration {
-
-		@Autowired
-		private CassandraClusterProperties cassandraClusterProperties;
-
-		@Autowired
-		private ReactiveCassandraTemplate reactiveCassandraTemplate;
-
-		@PostConstruct
-		public void init() throws IOException {
-			if (this.cassandraClusterProperties.getInitScript() != null) {
-				String scripts =
-						new Scanner(this.cassandraClusterProperties.getInitScript().getInputStream(), "UTF-8")
-								.useDelimiter("\\A")
-								.next();
-
-				ReactiveCqlOperations reactiveCqlOperations =
-						this.reactiveCassandraTemplate.getReactiveCqlOperations();
-
-				Flux.fromArray(StringUtils.delimitedListToStringArray(scripts, ";", "\r\n\f"))
-						.filter(StringUtils::hasText) // an empty String after the last ';'
-						.flatMap(script -> reactiveCqlOperations.execute(script + ";"))
-						.blockLast();
-			}
 		}
 
 	}

--- a/consumer/cassandra-consumer/src/main/java/io/pivotal/java/function/cassandra/consumer/cluster/CassandraClusterProperties.java
+++ b/consumer/cassandra-consumer/src/main/java/io/pivotal/java/function/cassandra/consumer/cluster/CassandraClusterProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package io.pivotal.java.function.cassandra.consumer.cluster;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.io.Resource;
-import org.springframework.data.cassandra.config.CassandraClusterFactoryBean;
 
 /**
  * Common properties for the cassandra modules.
@@ -46,11 +45,6 @@ public class CassandraClusterProperties {
 	private boolean skipSslValidation;
 
 	/**
-	 * Enable/disable metrics collection for the created cluster.
-	 */
-	private boolean metricsEnabled = CassandraClusterFactoryBean.DEFAULT_METRICS_ENABLED;
-
-	/**
 	 * Base packages to scan for entities annotated with Table annotations.
 	 */
 	private String[] entityBasePackages = { };
@@ -64,10 +58,6 @@ public class CassandraClusterProperties {
 		this.initScript = initScript;
 	}
 
-	public void setMetricsEnabled(boolean metricsEnabled) {
-		this.metricsEnabled = metricsEnabled;
-	}
-
 	public void setSkipSslValidation(boolean skipSslValidation) {
 		this.skipSslValidation = skipSslValidation;
 	}
@@ -78,10 +68,6 @@ public class CassandraClusterProperties {
 
 	public Resource getInitScript() {
 		return this.initScript;
-	}
-
-	public boolean isMetricsEnabled() {
-		return this.metricsEnabled;
 	}
 
 	public boolean isSkipSslValidation() {

--- a/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraConsumerApplicationTests.java
+++ b/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraConsumerApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,8 @@
 
 package io.pivotal.java.function.cassandra.consumer;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
@@ -30,24 +28,16 @@ import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.cassandra.core.CassandraOperations;
 import org.springframework.data.cassandra.core.WriteResult;
-import org.springframework.integration.support.json.Jackson2JsonObjectMapper;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.util.StringUtils;
 
-import com.datastax.driver.core.utils.UUIDs;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import io.pivotal.java.function.cassandra.consumer.domain.Book;
 import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 
 /**
  * @author Artem Bilan
@@ -57,6 +47,7 @@ import reactor.test.StepVerifier;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
 		properties = {
 				"spring.data.cassandra.keyspaceName=" + CassandraConsumerApplicationTests.CASSANDRA_KEYSPACE,
+				"spring.data.cassandra.localDatacenter=datacenter1",
 				"cassandra.cluster.createKeyspace=true" })
 @EmbeddedCassandra(configuration = EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE, timeout = 120000)
 @DirtiesContext
@@ -73,12 +64,13 @@ abstract class CassandraConsumerApplicationTests {
 	@BeforeAll
 	static void setUp() {
 		EmbeddedCassandraServerHelper.getSession();
-		System.setProperty("spring.data.cassandra.port", "" + EmbeddedCassandraServerHelper.getNativeTransportPort());
+		System.setProperty("spring.data.cassandra.contactPoints",
+				EmbeddedCassandraServerHelper.getHost() + ':' + EmbeddedCassandraServerHelper.getNativeTransportPort());
 	}
 
 	@AfterAll
 	static void cleanup() {
-		System.clearProperty("spring.data.cassandra.port");
+		System.clearProperty("spring.data.cassandra.contactPoints");
 	}
 
 	@AfterEach
@@ -98,7 +90,7 @@ abstract class CassandraConsumerApplicationTests {
 			b.setAuthor("SCDF Guru");
 			b.setPages(i * 10 + 5);
 			b.setInStock(true);
-			b.setSaleDate(new Date());
+			b.setSaleDate(LocalDate.now());
 			books.add(b);
 		}
 

--- a/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraConsumerApplicationTests.java
+++ b/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraConsumerApplicationTests.java
@@ -28,6 +28,8 @@ import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraEntityInsertTests.java
+++ b/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraEntityInsertTests.java
@@ -22,6 +22,8 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import org.springframework.data.cassandra.core.WriteResult;
 import org.springframework.test.context.TestPropertySource;
@@ -33,6 +35,7 @@ import reactor.test.StepVerifier;
 /**
  * @author Artem Bilan
  */
+@DisabledOnOs(OS.WINDOWS)
 @TestPropertySource(properties = {
 		"spring.data.cassandra.schema-action=RECREATE",
 		"cassandra.cluster.entity-base-packages=io.pivotal.java.function.cassandra.consumer.domain" })

--- a/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraEntityInsertTests.java
+++ b/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraEntityInsertTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,14 @@ package io.pivotal.java.function.cassandra.consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Date;
+import java.time.LocalDate;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.data.cassandra.core.WriteResult;
 import org.springframework.test.context.TestPropertySource;
 
-import com.datastax.driver.core.utils.UUIDs;
 import io.pivotal.java.function.cassandra.consumer.domain.Book;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -41,11 +41,11 @@ class CassandraEntityInsertTests extends CassandraConsumerApplicationTests {
 	@Test
 	void testInsert() {
 		Book book = new Book();
-		book.setIsbn(UUIDs.timeBased());
+		book.setIsbn(UUID.randomUUID());
 		book.setTitle("Spring Integration Cassandra");
 		book.setAuthor("Cassandra Guru");
 		book.setPages(521);
-		book.setSaleDate(new Date());
+		book.setSaleDate(LocalDate.now());
 		book.setInStock(true);
 
 		Mono<? extends WriteResult> result = this.cassandraConsumer.apply(book);

--- a/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraIngestInsertTests.java
+++ b/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraIngestInsertTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import org.springframework.data.cassandra.core.WriteResult;
 import org.springframework.integration.support.json.Jackson2JsonObjectMapper;
@@ -35,6 +37,7 @@ import reactor.test.StepVerifier;
 /**
  * @author Artem Bilan
  */
+@DisabledOnOs(OS.WINDOWS)
 @TestPropertySource(properties = {
 		"cassandra.cluster.init-script=init-db.cql",
 		"cassandra.ingest-query=" +

--- a/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraIngestNamedParamsTests.java
+++ b/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraIngestNamedParamsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import org.springframework.data.cassandra.core.WriteResult;
 import org.springframework.integration.support.json.Jackson2JsonObjectMapper;
@@ -36,6 +38,7 @@ import reactor.test.StepVerifier;
 /**
  * @author Artem Bilan
  */
+@DisabledOnOs(OS.WINDOWS)
 @TestPropertySource(properties = {
 		"cassandra.cluster.init-script=init-db.cql",
 		"cassandra.ingest-query=" +

--- a/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraIngestUpdateTests.java
+++ b/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/CassandraIngestUpdateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import org.springframework.data.cassandra.core.WriteResult;
 import org.springframework.integration.support.json.Jackson2JsonObjectMapper;
@@ -35,6 +37,7 @@ import reactor.test.StepVerifier;
 /**
  * @author Artem Bilan
  */
+@DisabledOnOs(OS.WINDOWS)
 @TestPropertySource(properties = {
 		"cassandra.cluster.init-script=init-db.cql",
 		"cassandra.ingest-query=" +

--- a/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/domain/Book.java
+++ b/consumer/cassandra-consumer/src/test/java/io/pivotal/java/function/cassandra/consumer/domain/Book.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors
+ * Copyright 2015-2020 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.pivotal.java.function.cassandra.consumer.domain;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.UUID;
 
 import org.springframework.data.cassandra.core.mapping.PrimaryKey;
@@ -40,7 +40,7 @@ public class Book {
 
 	private int pages;
 
-	private Date saleDate;
+	private LocalDate saleDate;
 
 	private boolean inStock;
 
@@ -63,14 +63,14 @@ public class Book {
 	/**
 	 * @return Returns the saleDate.
 	 */
-	public Date getSaleDate() {
+	public LocalDate getSaleDate() {
 		return this.saleDate;
 	}
 
 	/**
 	 * @param saleDate The saleDate to set.
 	 */
-	public void setSaleDate(Date saleDate) {
+	public void setSaleDate(LocalDate saleDate) {
 		this.saleDate = saleDate;
 	}
 

--- a/consumer/mongodb-consumer/pom.xml
+++ b/consumer/mongodb-consumer/pom.xml
@@ -13,10 +13,6 @@
         <version>1.0.0.BUILD-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <mongodb-driver.version>1.12.0</mongodb-driver.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.integration</groupId>
@@ -25,7 +21,6 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-reactivestreams</artifactId>
-            <version>${mongodb-driver.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/consumer/pom.xml
+++ b/consumer/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>io.pivotal.java.function</groupId>
 	<artifactId>java-functions-consumer</artifactId>
 	<version>1.0.0.BUILD-SNAPSHOT</version>
 	<name>java-functions-consumer</name>
@@ -17,7 +16,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 	</properties>
-	
+
   	<modules>
 <!--		<module>cassandra-consumer</module>-->
 		<module>log-consumer</module>

--- a/consumer/pom.xml
+++ b/consumer/pom.xml
@@ -18,7 +18,7 @@
 	</properties>
 
   	<modules>
-<!--		<module>cassandra-consumer</module>-->
+		<module>cassandra-consumer</module>
 		<module>log-consumer</module>
 		<module>mongodb-consumer</module>
 		<module>rabbit-consumer</module>

--- a/function/pom.xml
+++ b/function/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>io.pivotal.java.function</groupId>
 	<artifactId>java-functions-function</artifactId>
 	<version>1.0.0.BUILD-SNAPSHOT</version>
 	<name>java-functions-function</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.0.M1</version>
+		<version>2.3.0.M2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/supplier/mongodb-supplier/pom.xml
+++ b/supplier/mongodb-supplier/pom.xml
@@ -19,6 +19,10 @@
             <artifactId>spring-integration-mongodb</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>

--- a/supplier/mongodb-supplier/src/test/java/io/pivotal/java/function/mongo/supplier/MongodbSupplierApplicationTests.java
+++ b/supplier/mongodb-supplier/src/test/java/io/pivotal/java/function/mongo/supplier/MongodbSupplierApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import org.bson.Document;

--- a/supplier/pom.xml
+++ b/supplier/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>io.pivotal.java.function</groupId>
 	<artifactId>java-functions-supplier</artifactId>
 	<version>1.0.0.BUILD-SNAPSHOT</version>
 	<name>java-functions-supplier</name>


### PR DESCRIPTION
* Upgrade MongoDb functions to the latest supported driver; fix compatibility
* Upgrade `cassandra-consumer` to the latest Spring Data and Spring Integration Cassandra
* Remove redundant options from POMs

NOTE: Cassandra Consumer is not ready yet.
We can't create a `keyspace` any more with the latest Spring Boot