### PR TITLE
Consistent handling of byte array text input

### DIFF
--- a/consumer/counter-consumer/pom.xml
+++ b/consumer/counter-consumer/pom.xml
@@ -17,6 +17,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>io.pivotal.java.function</groupId>
+			<artifactId>payload-converter-function</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-integration</artifactId>
 		</dependency>

--- a/consumer/counter-consumer/src/test/java/io/pivotal/java/function/counter/consumer/ConverterFunctionAdapter.java
+++ b/consumer/counter-consumer/src/test/java/io/pivotal/java/function/counter/consumer/ConverterFunctionAdapter.java
@@ -1,0 +1,22 @@
+package io.pivotal.java.function.counter.consumer;
+
+import java.util.function.Function;
+
+import org.springframework.core.convert.converter.Converter;
+
+/**
+ * @author Christian Tzolov
+ */
+public class ConverterFunctionAdapter<S, T>  implements Converter<S, T> {
+
+	private Function<S, T> function;
+
+	public ConverterFunctionAdapter(Function<S, T> function) {
+		this.function = function;
+	}
+
+	@Override
+	public T convert(S s) {
+		return this.function.apply(s);
+	}
+}

--- a/consumer/log-consumer/pom.xml
+++ b/consumer/log-consumer/pom.xml
@@ -16,6 +16,12 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>io.pivotal.java.function</groupId>
+			<artifactId>payload-converter-function</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-integration</artifactId>
 		</dependency>

--- a/consumer/log-consumer/src/main/java/io/pivotal/java/function/log/consumer/LogConsumerConfiguration.java
+++ b/consumer/log-consumer/src/main/java/io/pivotal/java/function/log/consumer/LogConsumerConfiguration.java
@@ -24,7 +24,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
 
 /**
  * The Configuration class for {@link Consumer} which logs incoming data.
@@ -43,23 +42,11 @@ public class LogConsumerConfiguration {
 	@Bean
 	IntegrationFlow logConsumerFlow(LogConsumerProperties logSinkProperties) {
 		return IntegrationFlows.from(MessageConsumer.class, (gateway) -> gateway.beanName("logConsumer"))
-				.handle((payload, headers) -> {
-					if (payload instanceof byte[]) {
-						String contentType =
-								headers.containsKey(MessageHeaders.CONTENT_TYPE)
-										? headers.get(MessageHeaders.CONTENT_TYPE).toString()
-										: "application/json";
-						if (contentType.contains("text") || contentType.contains("json")
-								|| contentType.contains("x-spring-tuple")) {
-							return new String((byte[]) payload);
-						}
-					}
-					return payload;
-				})
+				.handle((payload, headers) -> payload)
 				.log(logSinkProperties.getLevel(), logSinkProperties.getName(), logSinkProperties.getExpression())
 				.get();
 	}
 
-	private interface MessageConsumer extends Consumer<Message<?>> { }
+	private interface MessageConsumer extends Consumer<Message<?>> {}
 
 }

--- a/consumer/log-consumer/src/test/java/io/pivotal/java/function/log/consumer/LogConsumerApplicationTests.java
+++ b/consumer/log-consumer/src/test/java/io/pivotal/java/function/log/consumer/LogConsumerApplicationTests.java
@@ -16,11 +16,6 @@
 
 package io.pivotal.java.function.log.consumer;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import java.util.function.Consumer;
 
 import org.apache.commons.logging.Log;
@@ -40,6 +35,11 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.util.MimeType;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 /**
  * @author Artem Bilan
  */
@@ -53,15 +53,6 @@ class LogConsumerApplicationTests {
 	@Autowired
 	@Qualifier("logConsumerFlow.logging-channel-adapter#0")
 	private LoggingHandler loggingHandler;
-
-	@Test
-	public void testTextContentType() {
-		Message<byte[]> message =
-				MessageBuilder.withPayload("{\"foo\":\"bar\"}".getBytes())
-						.setHeader("contentType", MimeType.valueOf("text/plain"))
-						.build();
-		testMessage(message, "{\"foo\":\"bar\"}");
-	}
 
 	@Test
 	public void testJsonContentType() {

--- a/function/payload-converter-function/pom.xml
+++ b/function/payload-converter-function/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>spel-function</artifactId>
+	<artifactId>payload-converter-function</artifactId>
 	<version>1.0.0.BUILD-SNAPSHOT</version>
-	<name>spel-function</name>
-	<description>Spring Native Function for applying SpEL expressions</description>
+	<name>payload-converter-function</name>
+	<description>Utility message conversion functions</description>
 
 	<parent>
 		<groupId>io.pivotal.java.function</groupId>
@@ -16,15 +17,10 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>io.pivotal.java.function</groupId>
-			<artifactId>payload-converter-function</artifactId>
-			<version>${project.version}</version>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-messaging</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-integration</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -35,11 +31,6 @@
 					<artifactId>junit-vintage-engine</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/function/payload-converter-function/src/main/java/functions/ByteArrayTextToString.java
+++ b/function/payload-converter-function/src/main/java/functions/ByteArrayTextToString.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package functions;
+
+import java.util.function.Function;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.MimeTypeUtils;
+
+/**
+ *
+ * @author Christian Tzolov
+ */
+public class ByteArrayTextToString implements Function<Message<?>, Message<?>> {
+
+	@Override
+	public Message<?> apply(Message<?> message) {
+
+		if (message.getPayload() instanceof byte[]) {
+			final MessageHeaders headers = message.getHeaders();
+			String contentType = headers.containsKey(MessageHeaders.CONTENT_TYPE)
+					? headers.get(MessageHeaders.CONTENT_TYPE).toString()
+					: MimeTypeUtils.APPLICATION_JSON_VALUE;
+
+			if (contentType.contains("text") || contentType.contains("json") || contentType.contains("x-spring-tuple")) {
+				message = MessageBuilder.withPayload(new String(((byte[]) message.getPayload())))
+						.copyHeaders(message.getHeaders())
+						.build();
+			}
+		}
+
+		return message;
+	}
+}
+

--- a/function/payload-converter-function/src/test/java/functions/ByteArrayTextToStringTests.java
+++ b/function/payload-converter-function/src/test/java/functions/ByteArrayTextToStringTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2011-2020 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package functions;
+
+import java.util.Collections;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.util.MimeTypeUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ByteArrayTextToStringTests {
+
+	private static final String MESSAGE = "hello world";
+	private static Function<Message<?>, Message<?>> converter;
+
+	@BeforeAll
+	static void before() {
+		converter = new ByteArrayTextToString();
+	}
+
+	@Test
+	public void testDefaultNoContentType() {
+		Message<?> converted = converter.apply(new GenericMessage<>(MESSAGE.getBytes()));
+		assertThat(converted).isNotNull().extracting(Message::getPayload).isEqualTo(MESSAGE);
+
+		converted = converter.apply(new GenericMessage<>(MESSAGE)); // String
+		assertThat(converted).isNotNull().extracting(Message::getPayload).isEqualTo(MESSAGE);
+	}
+
+	@Test
+	public void testApplicationJsonContentType() {
+		Message<?> converted = converter.apply(new GenericMessage<>(MESSAGE.getBytes(),
+				Collections.singletonMap(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON_VALUE)));
+		assertThat(converted).isNotNull().extracting(Message::getPayload).isEqualTo("hello world");
+	}
+
+	@Test
+	public void testPlainTextContentType() {
+		Message<?> converted = converter.apply(new GenericMessage<>(MESSAGE.getBytes(),
+				Collections.singletonMap(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)));
+		assertThat(converted).isNotNull().extracting(Message::getPayload).isEqualTo(MESSAGE);
+	}
+
+	@Test
+	public void testOctetContentType() {
+		Message<?> converted = converter.apply(new GenericMessage<>(MESSAGE.getBytes(),
+				Collections.singletonMap(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE)));
+		assertThat(converted).isNotNull().extracting(Message::getPayload).isEqualTo(MESSAGE.getBytes());
+	}
+
+	@Test
+	public void testRandomNonTextContentType() {
+		Message<?> converted = converter.apply(new GenericMessage<>(MESSAGE.getBytes(),
+				Collections.singletonMap(MessageHeaders.CONTENT_TYPE, "Random Content Type")));
+		assertThat(converted).isNotNull().extracting(Message::getPayload).isEqualTo(MESSAGE.getBytes());
+	}
+
+}

--- a/function/spel-function/src/main/java/io/pivotal/java/function/spel/function/SpelFunctionConfiguration.java
+++ b/function/spel-function/src/main/java/io/pivotal/java/function/spel/function/SpelFunctionConfiguration.java
@@ -24,8 +24,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.transformer.ExpressionEvaluatingTransformer;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
-import org.springframework.messaging.support.MessageBuilder;
 
 @Configuration
 @EnableConfigurationProperties(SpelFunctionProperties.class)
@@ -35,23 +33,7 @@ public class SpelFunctionConfiguration {
 	public Function<Message<?>, Message<?>> spelFunction(
 			ExpressionEvaluatingTransformer expressionEvaluatingTransformer) {
 
-		return message -> {
-			if (message.getPayload() instanceof byte[]) {
-				final MessageHeaders headers = message.getHeaders();
-				String contentType =
-						headers.containsKey(MessageHeaders.CONTENT_TYPE)
-								? headers.get(MessageHeaders.CONTENT_TYPE).toString()
-								: "application/json";
-				if (contentType.contains("text") || contentType.contains("json")
-						|| contentType.contains("x-spring-tuple")) {
-
-					message = MessageBuilder.withPayload(new String(((byte[]) message.getPayload())))
-							.copyHeaders(message.getHeaders())
-							.build();
-				}
-			}
-			return expressionEvaluatingTransformer.transform(message);
-		};
+		return message -> expressionEvaluatingTransformer.transform(message);
 	}
 
 	@Bean
@@ -61,6 +43,5 @@ public class SpelFunctionConfiguration {
 		return new ExpressionEvaluatingTransformer(new SpelExpressionParser()
 				.parseExpression(spelFunctionProperties.getExpression()));
 	}
-
 
 }

--- a/function/spel-function/src/test/java/io/pivotal/java/function/spel/function/SpelFunctionApplicationTests.java
+++ b/function/spel-function/src/test/java/io/pivotal/java/function/spel/function/SpelFunctionApplicationTests.java
@@ -19,6 +19,7 @@ package io.pivotal.java.function.spel.function;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,7 +47,7 @@ public class SpelFunctionApplicationTests {
 
 	@Test
 	public void testJson() {
-		Message<byte[]> message = MessageBuilder.withPayload("{\"foo\":\"bar\"}".getBytes())
+		Message<?> message = MessageBuilder.withPayload("{\"foo\":\"bar\"}")
 				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON).build();
 		final Message<?> transformed = this.transformer.apply(message);
 		assertThat(transformed.getPayload()).isEqualTo("{\"FOO\":\"BAR\"}");

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,13 @@
 		<module>function/filter-function</module>
 		<module>function/spel-function</module>
 		<module>function/splitter-function</module>
+		<module>function/payload-converter-function</module>
 
 		<module>supplier/http-supplier</module>
 		<module>supplier/jdbc-supplier</module>
 		<module>supplier/mongodb-supplier</module>
 		<module>supplier/time-supplier</module>
+
 		<module>spring-functions-parent</module>
 	</modules>
 


### PR DESCRIPTION
 - Move the byte array text to String conversion logic into a standalone ByteArrayTextToString top-level function part of the payload-converter-function project.
 - Remove the byte array text to String conversion form the various supplier, function and consumer projects. Use function composition instead. e.g. byteArrayTextToString | logConsumer.