### PR TITLE
Fix properties prefix in the configuration

### DIFF
--- a/supplier/jdbc-supplier/src/main/java/io/pivotal/java/function/jdbc/supplier/JdbcSupplierConfiguration.java
+++ b/supplier/jdbc-supplier/src/main/java/io/pivotal/java/function/jdbc/supplier/JdbcSupplierConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,10 @@ import org.springframework.integration.jdbc.JdbcPollingChannelAdapter;
 import org.springframework.messaging.Message;
 import reactor.core.publisher.Flux;
 
+/**
+ * @author Soby Chacko
+ * @author Artem Bilan
+ */
 @Configuration
 @EnableConfigurationProperties(JdbcSupplierProperties.class)
 @Import(SplitterFunctionConfiguration.class)
@@ -58,7 +62,7 @@ public class JdbcSupplierConfiguration {
 
 	@Bean(name = "jdbcSupplier")
 	@PollableBean(splittable = true)
-	@ConditionalOnProperty(prefix = "jdbc", name = "split", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = "jdbc.supplier", name = "split", matchIfMissing = true)
 	public Supplier<Flux<Message<?>>> splittedSupplier(Function<Message<?>, List<Message<?>>> splitterFunction) {
 		return () -> {
 			Message<?> received = jdbcMessageSource().receive();
@@ -72,7 +76,7 @@ public class JdbcSupplierConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = "jdbc", name = "split", havingValue = "false")
+	@ConditionalOnProperty(prefix = "jdbc.supplier", name = "split", havingValue = "false")
 	public Supplier<Message<?>> jdbcSupplier() {
 		return () -> jdbcMessageSource().receive();
 	}

--- a/supplier/jdbc-supplier/src/main/java/io/pivotal/java/function/jdbc/supplier/JdbcSupplierProperties.java
+++ b/supplier/jdbc-supplier/src/main/java/io/pivotal/java/function/jdbc/supplier/JdbcSupplierProperties.java
@@ -21,6 +21,10 @@ import javax.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+/**
+ * @author Soby Chacko
+ * @author Artem Bilan
+ */
 @ConfigurationProperties("jdbc.supplier")
 @Validated
 public class JdbcSupplierProperties {

--- a/supplier/jdbc-supplier/src/test/java/io/pivotal/java/function/jdbc/supplier/NonSplitJdbcSupplierTests.java
+++ b/supplier/jdbc-supplier/src/test/java/io/pivotal/java/function/jdbc/supplier/NonSplitJdbcSupplierTests.java
@@ -30,9 +30,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Soby Chacko
+ * @author Artem Bilan
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = {"jdbc.supplier.query=select id, name from test order by id", "jdbc.split=false"})
+		properties = {"jdbc.supplier.query=select id, name from test order by id", "jdbc.supplier.split=false"})
 @DirtiesContext
 public class NonSplitJdbcSupplierTests {
 


### PR DESCRIPTION
The `JdbcSupplierProperties` exposes a `jdbc.supplier` prefix,
but `JdbcSupplierConfiguration` uses a `jdbc` only for conditions
making a wrong assumption in the target function consumer

* Fix `JdbcSupplierConfiguration` to use a proper `jdbc.supplier`
* Fix `NonSplitJdbcSupplierTests` respectively